### PR TITLE
Fix invalid map name being used for bombsite/point distance

### DIFF
--- a/csgo/analytics/distance.py
+++ b/csgo/analytics/distance.py
@@ -16,6 +16,21 @@ def bombsite_distance(location, bombsite="A", map="de_dust2"):
         bombsite: A string indicating the bombsite (A or B)
         map: A string indicating the map
     """
+
+    if map not in [
+        "de_dust2",
+        "de_cbble",
+        "de_inferno",
+        "de_mirage",
+        "de_nuke",
+        "de_overpass",
+        "de_train",
+        "de_vertigo",
+    ]:
+        raise ValueError(
+            f'Invalid map name: got {map}, expected one of: "de_dust2", "de_cbble", "de_inferno", "de_mirage", "de_nuke", "de_overpass", "de_train", "de_vertigo"'
+        )
+
     path = os.path.join(os.path.dirname(__file__), "")
     proc = subprocess.Popen(
         [
@@ -48,6 +63,21 @@ def point_distance(point_a, point_b, type="graph", map="de_dust2"):
         type: A string that is one of 'euclidean', 'manhattan', 'canberra', 'cosine' or 'graph'. Using 'graph' will use A* to find the shortest path and counts the discrete areas it travels.
         map: A string indicating the map
     """
+
+    if map not in [
+        "de_dust2",
+        "de_cbble",
+        "de_inferno",
+        "de_mirage",
+        "de_nuke",
+        "de_overpass",
+        "de_train",
+        "de_vertigo",
+    ]:
+        raise ValueError(
+            f'Invalid map name: got {map}, expected one of: "de_dust2", "de_cbble", "de_inferno", "de_mirage", "de_nuke", "de_overpass", "de_train", "de_vertigo"'
+        )
+
     if type == "graph":
         path = os.path.join(os.path.dirname(__file__), "")
         proc = subprocess.Popen(

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -28,3 +28,19 @@ class TestCSGOAnalytics:
         """ Test polygon area function
         """
         assert polygon_area([0, 1, 2], [0, 1, 0]) == 1.0
+
+    def test_bombsite_invalid_map(self):
+        """
+        Test bombsite function with an invalid map.
+        """
+
+        with pytest.raises(ValueError):
+            bombsite_distance([0, 0, 0], map="dust2")
+
+    def test_point_invalid_map(self):
+        """
+        Test point distance function with an invalid map.
+        """
+
+        with pytest.raises(ValueError):
+            point_distance([0, 0, 0], [1, 1, 1], map="dust2")


### PR DESCRIPTION
If an invalid map name is used for bombsite/point distance functions, this code makes the function throw a `ValueError` with clarifying instructions.

Ran this through black before committing. I also added a couple of tests making sure that the error was raised. Let me know if you need anything else :)