### PR TITLE
Setup fixes

### DIFF
--- a/csgo/__init__.py
+++ b/csgo/__init__.py
@@ -1,9 +1,10 @@
 import lzma
 import os
 import pickle
-import brotli
+
+# import brotli
 
 from csgo.utils import AutoVivification
 
 path = os.path.join(os.path.dirname(__file__), "")
-DIST_DICT = pickle.load(lzma.open(path + "/data/nav/distances.xz", "rb"))
+DIST_DICT = pickle.load(lzma.open(path + "data/nav/distances.xz", "rb"))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,14 @@ setup(
     ],
     package_data={
         # If any package contains *.txt or *.rst files, include them:
-        "": ["*.go", "data/map/*.png", "data/nav/*.nav", "*.mod", "*.sum",]
+        "": [
+            "*.go",
+            "data/map/*.png",
+            "data/nav/*.nav",
+            "data/nav/*.xz",
+            "*.mod",
+            "*.sum",
+        ]
     },
     # metadata to display on PyPI
     author="Peter Xenopoulos",


### PR DESCRIPTION
Removes the `brotli` import, fixes the dir issue with dist_dict, and adds the `.xz` files in `data/nav` to `setup.py`.