### PR TITLE
Fixed bomb plant bug

### DIFF
--- a/csgo/parser/parse_demo.go
+++ b/csgo/parser/parse_demo.go
@@ -2267,8 +2267,12 @@ func main() {
 			currentWorldObj.Z = float64(objPos.Z)
 			currentFrame.World = append(currentFrame.World, currentWorldObj)
 			if len(currentRound.Bomb) > 0 {
-				currentFrame.BombPlanted = true
-				currentFrame.BombSite = currentRound.Bomb[0].BombSite
+				for _, b := range currentRound.Bomb {
+					if b.BombAction = "plant" {
+						currentFrame.BombPlanted = true
+						currentFrame.BombSite = b.BombSite
+					}
+				}	
 			} else {
 				currentFrame.BombPlanted = false
 			}


### PR DESCRIPTION
Fixed a bug where the bombplant flag was determined by first bomb action -- this is incorrect logic as a player could stop planting and run to another site or replant.