### PR TITLE
Outsourced conversion from json to dataframe to a seperate function for easier access later. Also fixed a bug in remove_warumps()

### DIFF
--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -566,7 +566,6 @@ class DemoParser:
                 if not r["isWarmup"]:
                     cleaned_rounds.append(r)
             self.json["gameRounds"] = cleaned_rounds
-            cleaned_rounds = []
             # Now, remove warmups where the demo may have started recording in the middle of a warmup round
             if "warmupChanged" in self.json["matchPhases"]:
                 if len(self.json["matchPhases"]["warmupChanged"]) > 1:

--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -219,22 +219,7 @@ class DemoParser:
             if return_type == "json":
                 return self.json
             elif return_type == "df":
-                demo_data = {}
-                demo_data["matchID"] = self.json["matchID"]
-                demo_data["clientName"] = self.json["clientName"]
-                demo_data["mapName"] = self.json["mapName"]
-                demo_data["tickRate"] = self.json["tickRate"]
-                demo_data["playbackTicks"] = self.json["playbackTicks"]
-                demo_data["rounds"] = self._parse_rounds()
-                demo_data["kills"] = self._parse_kills()
-                demo_data["damages"] = self._parse_damages()
-                demo_data["grenades"] = self._parse_grenades()
-                demo_data["flashes"] = self._parse_flashes()
-                demo_data["weaponFires"] = self._parse_weapon_fires()
-                demo_data["bombEvents"] = self._parse_bomb_events()
-                demo_data["frames"] = self._parse_frames()
-                demo_data["playerFrames"] = self._parse_player_frames()
-                self.logger.info("Returned dataframe output")
+                demo_data = self._parse_json()
                 return demo_data
             else:
                 self.logger.error("Parse return_type must be either 'json' or 'df'")
@@ -242,6 +227,25 @@ class DemoParser:
         else:
             self.logger.error("JSON couldn't be returned")
             raise AttributeError("No JSON parsed!")
+
+    def _parse_json(self):
+        demo_data = {}
+        demo_data["matchID"] = self.json["matchID"]
+        demo_data["clientName"] = self.json["clientName"]
+        demo_data["mapName"] = self.json["mapName"]
+        demo_data["tickRate"] = self.json["tickRate"]
+        demo_data["playbackTicks"] = self.json["playbackTicks"]
+        demo_data["rounds"] = self._parse_rounds()
+        demo_data["kills"] = self._parse_kills()
+        demo_data["damages"] = self._parse_damages()
+        demo_data["grenades"] = self._parse_grenades()
+        demo_data["flashes"] = self._parse_flashes()
+        demo_data["weaponFires"] = self._parse_weapon_fires()
+        demo_data["bombEvents"] = self._parse_bomb_events()
+        demo_data["frames"] = self._parse_frames()
+        demo_data["playerFrames"] = self._parse_player_frames()
+        self.logger.info("Returned dataframe output")
+        return demo_data
 
     def _parse_frames(self):
         """Returns frames as either a list or Pandas dataframe


### PR DESCRIPTION
Currently if i have parsed a demo and exported the json and i want to later have a look at it again i i have to manually transform it to a data frame by calling the functions seperatly. 

I also found and fixed a bug in remove_warmups() that caused it to basically remove all rounds.