### PR TITLE
Added option to set indentation when writing json file. Also added a null check to remove_excess_players.

### DIFF
--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -35,6 +35,7 @@ class DemoParser:
         trade_time=5,
         dmg_rolled=False,
         buy_style="hltv",
+        json_indentation=False,
     ):
         # Set up logger
         if log:
@@ -122,8 +123,10 @@ class DemoParser:
 
         self.dmg_rolled = dmg_rolled
         self.parse_frames = parse_frames
+        self.json_indentation = json_indentation
         self.logger.info("Rollup damages set to " + str(self.dmg_rolled))
         self.logger.info("Parse frames set to " + str(self.parse_frames))
+        self.logger.info("Output json indentation set to " + str(self.json_indentation))
 
         # Set parse error to False
         self.parse_error = False
@@ -179,6 +182,8 @@ class DemoParser:
             self.parser_cmd.append("--dmgrolled")
         if self.parse_frames:
             self.parser_cmd.append("--parseframes")
+        if self.json_indentation:
+            self.parser_cmd.append("--jsonindentation")
         proc = subprocess.Popen(
             self.parser_cmd,
             stdout=subprocess.PIPE,
@@ -605,7 +610,6 @@ class DemoParser:
         remove_excess_kills=True,
         remove_bad_endings=True,
         return_type="json",
-        json_indent=None,
     ):
         """Cleans a parsed demofile JSON.
 
@@ -646,7 +650,7 @@ class DemoParser:
                 self.remove_end_round()
             self.renumber_rounds()
             self.rescore_rounds()
-            self.write_json(indent=json_indent)
+            self.write_json()
             if return_type == "json":
                 return self.json
             elif return_type == "df":
@@ -661,10 +665,10 @@ class DemoParser:
                 "JSON not found. Run .parse() or .read_json() if JSON already exists"
             )
 
-    def write_json(self, indent=None):
+    def write_json(self):
         """Rewrite the JSON file"""
         with open(self.output_file, "w", encoding="utf8") as fp:
-            json.dump(self.json, fp, indent=indent)
+            json.dump(self.json, fp, indent=(1 if self.json_indentation else None))
 
     def renumber_rounds(self):
         """Renumbers the rounds.

--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -761,11 +761,14 @@ class DemoParser:
             for r in self.json["gameRounds"]:
                 if len(r["frames"]) > 0:
                     f = r["frames"][0]
-                    if f["ct"]["players"] == None or f["t"]["players"] == None:
-                        cleaned_rounds.append(r)
-                        self.logger.warning("This round does not have players for at least one side in its first frame. Not cleaning excess players. Consider running the clean_rounds function with remove_excess_players=False!")
-                    elif (len(f["ct"]["players"]) <= 5) and (len(f["t"]["players"]) <= 5):
-                        cleaned_rounds.append(r)
+                    if f["ct"]["players"] == None:
+                        if f["t"]["players"] == None:
+                            pass
+                        elif len(f["t"]["players"]) <= 5:
+                            cleaned_rounds.append(r)
+                    elif len(f["ct"]["players"]) <= 5:
+                        if (f["t"]["players"] == None) or (len(f["t"]["players"]) <= 5):
+                            cleaned_rounds.append(r)
             self.json["gameRounds"] = cleaned_rounds
         else:
             self.logger.error(

--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -605,6 +605,7 @@ class DemoParser:
         remove_excess_kills=True,
         remove_bad_endings=True,
         return_type="json",
+        json_indent=None,
     ):
         """Cleans a parsed demofile JSON.
 
@@ -645,7 +646,7 @@ class DemoParser:
                 self.remove_end_round()
             self.renumber_rounds()
             self.rescore_rounds()
-            self.write_json()
+            self.write_json(indent=json_indent)
             if return_type == "json":
                 return self.json
             elif return_type == "df":
@@ -660,10 +661,10 @@ class DemoParser:
                 "JSON not found. Run .parse() or .read_json() if JSON already exists"
             )
 
-    def write_json(self):
+    def write_json(self, indent=None):
         """Rewrite the JSON file"""
         with open(self.output_file, "w", encoding="utf8") as fp:
-            json.dump(self.json, fp)
+            json.dump(self.json, fp, indent=indent)
 
     def renumber_rounds(self):
         """Renumbers the rounds.

--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -631,10 +631,6 @@ class DemoParser:
         """
         if self.json:
             if remove_no_frames:
-                if not self.parse_frames:
-                    self.logger.warning(
-                        "parse_frames is set to False, must be true for remove_no_frames to work."
-                    )
                 self.remove_rounds_with_no_frames()
             if remove_warmups:
                 self.remove_warmups()
@@ -740,11 +736,16 @@ class DemoParser:
             AttributeError: Raises an AttributeError if the .json attribute is None
         """
         if self.json:
-            cleaned_rounds = []
-            for r in self.json["gameRounds"]:
-                if len(r["frames"]) > 0:
-                    cleaned_rounds.append(r)
-            self.json["gameRounds"] = cleaned_rounds
+            if not self.parse_frames:
+                    self.logger.warning(
+                        "parse_frames is set to False, must be true for remove_no_frames to work. Skipping remove_no_frames."
+                    )
+            else:
+                cleaned_rounds = []
+                for r in self.json["gameRounds"]:
+                    if len(r["frames"]) > 0:
+                        cleaned_rounds.append(r)
+                self.json["gameRounds"] = cleaned_rounds
         else:
             self.logger.error(
                 "JSON not found. Run .parse() or .read_json() if JSON already exists"
@@ -760,20 +761,25 @@ class DemoParser:
             AttributeError: Raises an AttributeError if the .json attribute is None
         """
         if self.json:
-            cleaned_rounds = []
-            # Remove rounds where the number of players is too large
-            for r in self.json["gameRounds"]:
-                if len(r["frames"]) > 0:
-                    f = r["frames"][0]
-                    if f["ct"]["players"] == None:
-                        if f["t"]["players"] == None:
-                            pass
-                        elif len(f["t"]["players"]) <= 5:
-                            cleaned_rounds.append(r)
-                    elif len(f["ct"]["players"]) <= 5:
-                        if (f["t"]["players"] == None) or (len(f["t"]["players"]) <= 5):
-                            cleaned_rounds.append(r)
-            self.json["gameRounds"] = cleaned_rounds
+            if not self.parse_frames:
+                    self.logger.warning(
+                        "parse_frames is set to False, must be true for remove_no_frames to work. Skipping remove_no_frames."
+                    )
+            else:
+                cleaned_rounds = []
+                # Remove rounds where the number of players is too large
+                for r in self.json["gameRounds"]:
+                    if len(r["frames"]) > 0:
+                        f = r["frames"][0]
+                        if f["ct"]["players"] == None:
+                            if f["t"]["players"] == None:
+                                pass
+                            elif len(f["t"]["players"]) <= 5:
+                                cleaned_rounds.append(r)
+                        elif len(f["ct"]["players"]) <= 5:
+                            if (f["t"]["players"] == None) or (len(f["t"]["players"]) <= 5):
+                                cleaned_rounds.append(r)
+                self.json["gameRounds"] = cleaned_rounds
         else:
             self.logger.error(
                 "JSON not found. Run .parse() or .read_json() if JSON already exists"

--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -763,7 +763,7 @@ class DemoParser:
         if self.json:
             if not self.parse_frames:
                     self.logger.warning(
-                        "parse_frames is set to False, must be true for remove_no_frames to work. Skipping remove_no_frames."
+                        "parse_frames is set to False, must be true for remove_excess_players to work. Skipping remove_excess_players."
                     )
             else:
                 cleaned_rounds = []

--- a/csgo/parser/demoparser.py
+++ b/csgo/parser/demoparser.py
@@ -761,7 +761,10 @@ class DemoParser:
             for r in self.json["gameRounds"]:
                 if len(r["frames"]) > 0:
                     f = r["frames"][0]
-                    if (len(f["ct"]["players"]) <= 5) and (len(f["t"]["players"]) <= 5):
+                    if f["ct"]["players"] == None or f["t"]["players"] == None:
+                        cleaned_rounds.append(r)
+                        self.logger.warning("This round does not have players for at least one side in its first frame. Not cleaning excess players. Consider running the clean_rounds function with remove_excess_players=False!")
+                    elif (len(f["ct"]["players"]) <= 5) and (len(f["t"]["players"]) <= 5):
                         cleaned_rounds.append(r)
             self.json["gameRounds"] = cleaned_rounds
         else:

--- a/csgo/parser/parse_demo.go
+++ b/csgo/parser/parse_demo.go
@@ -778,6 +778,7 @@ func main() {
 	roundBuyPtr := fl.String("buystyle", "hltv", "Round buy style")
 	damagesRolledPtr := fl.Bool("dmgrolled", false, "Roll up damages")
 	demoIDPtr := fl.String("demoid", "", "Demo string ID")
+	jsonIndentationPtr := fl.Bool("jsonindentation", false, "Indent JSON file")
 	outpathPtr := fl.String("out", "", "Path to write output JSON")
 
 	err := fl.Parse(os.Args[1:])
@@ -789,6 +790,7 @@ func main() {
 	tradeTime := int64(*tradeTimePtr)
 	roundBuyStyle := *roundBuyPtr
 	damagesRolled := *damagesRolledPtr
+	jsonIndentation := *jsonIndentationPtr
 	outpath := *outpathPtr
 
 	// Read in demofile
@@ -2120,7 +2122,12 @@ func main() {
 		}
 		
 		// Write the JSON
-		file, _ := json.MarshalIndent(currentGame, "", " ")
+		var file []byte
+		if jsonIndentation {
+			file, _ = json.MarshalIndent(currentGame, "", " ")
+		} else {
+			file, _ = json.Marshal(currentGame)
+		}
 		_ = ioutil.WriteFile(outpath+"/"+currentGame.MatchName+".json", file, 0644)
 	}
 

--- a/tests/test_data.json
+++ b/tests/test_data.json
@@ -33,6 +33,6 @@
         "url": "https://storage.googleapis.com/csgo-tests/vitality-vs-g2-m2-mirage.dem"
     },
     "pov-clean": {
-        "url": "https://storage.googleapis.com/csgo-tests/41.dem"
+        "url": "https://storage.googleapis.com/csgo-tests/041.dem"
     }
 }

--- a/tests/test_data.json
+++ b/tests/test_data.json
@@ -31,5 +31,8 @@
     },
     "vitality-vs-g2-m2-mirage": {
         "url": "https://storage.googleapis.com/csgo-tests/vitality-vs-g2-m2-mirage.dem"
+    },
+    "pov-clean": {
+        "url": "https://storage.googleapis.com/csgo-tests/41.dem"
     }
 }

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -303,6 +303,6 @@ class TestDemoParser:
         self.player_clean_parser = DemoParser(
             demofile="pov-clean.dem", log=False, parse_frames=True
         )
-        self.player_clean_data = self.round_clean_parser.parse()
+        self.player_clean_data = self.player_clean_parser.parse()
         self.player_clean_parser.remove_excess_players()
         assert len(self.player_clean_data["gameRounds"]) == 28

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -297,3 +297,12 @@ class TestDemoParser:
         self.round_clean_data = self.round_clean_parser.parse()
         self.round_clean_parser.remove_time_rounds()
         assert len(self.round_clean_data["gameRounds"]) == 24
+
+    def test_player_clean(self):
+        """Tests that remove excess players is working."""
+        self.player_clean_parser = DemoParser(
+            demofile="pov-clean.dem", log=False, parse_frames=True
+        )
+        self.player_clean_data = self.round_clean_parser.parse()
+        self.player_clean_parser.remove_excess_players()
+        assert len(self.player_clean_data["gameRounds"]) == 28


### PR DESCRIPTION
Added the options to set the indentation in json.dump to write_json and also in clean_rounds which calls write_json. Kept the default at None which is the current behavior of write_json (since recently).

Interestingly the json written by parse_demo (where the writing occurs in the go code) seems to employ some indentation making the current defaults a bit inconsistent.

---

Additionally i added a None check to remove_excess_players in clean_rounds. It check whether both sides even have a none None ["players"] entry before cutting on their lengths. If either side has a None entry it accepts the round and gives a warning about that fact.

It would probably be a bit better to check each side one by one so that if one side is None and the other 5 the round is accepted by if the other side is >5 the round is not. Alternatively it could be an option to chose whether rounds with None sides should be kept or removed and if then the default should be set to keep or remove.